### PR TITLE
fix(duplicate-admin-signup): make sure no more than one admin with th…

### DIFF
--- a/src/main/java/com/lms/presentation/AuthenticationController.java
+++ b/src/main/java/com/lms/presentation/AuthenticationController.java
@@ -6,6 +6,7 @@ import com.lms.persistence.RegisterUserDto;
 import com.lms.persistence.User;
 import com.lms.service.AuthenticationService;
 import com.lms.service.JwtService;
+import com.lms.service.UserService;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,10 +20,12 @@ public class AuthenticationController {
     private final JwtService jwtService;
 
     private final AuthenticationService authenticationService;
+    private final UserService userService;
 
-    public AuthenticationController(JwtService jwtService, AuthenticationService authenticationService) {
+    public AuthenticationController(JwtService jwtService, AuthenticationService authenticationService, UserService userService) {
         this.jwtService = jwtService;
         this.authenticationService = authenticationService;
+        this.userService = userService;
     }
 
 //    @PostMapping("/signup")
@@ -37,6 +40,15 @@ public class AuthenticationController {
         if (!"Admin".equals(registerUserDto.getRole())) {
             return ResponseEntity.status(403).body("Access Denied: you are unauthorized");
         }
+
+        if(userService.findById(registerUserDto.getId()) != null) {
+            return ResponseEntity.status(409).body("Id already in use.");
+        }
+
+        if(userService.findByEmail(registerUserDto.getEmail()).isPresent()) {
+            return ResponseEntity.status(409).body("Email already in use.");
+        }
+
         User registeredUser = authenticationService.signup(registerUserDto);
         return ResponseEntity.ok(registeredUser);
     }


### PR DESCRIPTION
Prevent registering admin accounts with an existing id or an existing email.

Here is the referenced opened issue for this bug
#2 

This is the **UML Sequence Diagram** for the admin registration flow before the change

![image](https://github.com/user-attachments/assets/412cc1e6-a668-4354-98c8-332f7dce8011)

And this is updated diagram after the fix.

![image](https://github.com/user-attachments/assets/92edf80e-1b6f-47fb-a953-bbdaf9d6d221)