### PR TITLE
All replaceAll() has been fixed and changed by replace()

### DIFF
--- a/src/main/java/com/lms/persistence/Notification.java
+++ b/src/main/java/com/lms/persistence/Notification.java
@@ -12,7 +12,7 @@ import java.util.UUID;
 @NoArgsConstructor
 @AllArgsConstructor
 public class Notification {
-    private String id = UUID.randomUUID().toString().replaceAll("-", "").substring(0,6);
+    private String id = UUID.randomUUID().toString().replace("-", "").substring(0,6);
     private String userId;
     private String message;
     private boolean isRead = false;

--- a/src/main/java/com/lms/persistence/entities/questions/QuestionFactory.java
+++ b/src/main/java/com/lms/persistence/entities/questions/QuestionFactory.java
@@ -13,7 +13,7 @@ public class QuestionFactory {
     switch (type) {
       case "MCQ":
         return new MCQQuestion(
-          UUID.randomUUID().toString().replaceAll("-", "").substring(0, 6),
+          UUID.randomUUID().toString().replace("-", "").substring(0, 6),
           questionRequest.getQuestionText(),
           questionRequest.getGrade(),
           questionRequest.getOptions(),
@@ -21,14 +21,14 @@ public class QuestionFactory {
         );
       case "TrueFalse":
         return new TrueFalseQuestion(
-          UUID.randomUUID().toString().replaceAll("-", "").substring(0, 6),
+          UUID.randomUUID().toString().replace("-", "").substring(0, 6),
           questionRequest.getQuestionText(),
           questionRequest.getGrade(),
           questionRequest.getCorrectAnswerBoolean()
         );
       case "ShortAnswer":
         return new ShortAnswerQuestion(
-          UUID.randomUUID().toString().replaceAll("-", "").substring(0, 6),
+          UUID.randomUUID().toString().replace("-", "").substring(0, 6),
           questionRequest.getQuestionText(),
           questionRequest.getGrade(),
           questionRequest.getCorrectAnswer()

--- a/src/main/java/com/lms/service/CourseServiceImpl.java
+++ b/src/main/java/com/lms/service/CourseServiceImpl.java
@@ -28,7 +28,7 @@ public class CourseServiceImpl implements CourseService {
 
     @Override
     public Course createCourse(Course course) {
-        course.setId(UUID.randomUUID().toString().replaceAll("-", "").substring(0, 6)); // Generate unique ID
+        course.setId(UUID.randomUUID().toString().replace("-", "").substring(0, 6)); // Generate unique ID
         courseList.add(course);
         return course;
     }

--- a/src/main/java/com/lms/service/impl/QuizServiceImpl.java
+++ b/src/main/java/com/lms/service/impl/QuizServiceImpl.java
@@ -56,7 +56,7 @@ class QuizServiceImpl implements QuizService {
     );
 
     Quiz quiz = new Quiz(
-      UUID.randomUUID().toString().replaceAll("-", "").substring(0, 6),
+      UUID.randomUUID().toString().replace("-", "").substring(0, 6),
       courseId,
       name,
             instructorId,

--- a/src/main/java/com/lms/service/impl/QuizSubmissionServiceImpl.java
+++ b/src/main/java/com/lms/service/impl/QuizSubmissionServiceImpl.java
@@ -49,7 +49,7 @@ class QuizSubmissionServiceImpl implements QuizSubmissionService {
     List<Question> questions = quiz.getSelectedQuestions();
     QuizSubmission submission = new QuizSubmission();
     submission.setId(
-      UUID.randomUUID().toString().replaceAll("-", "").substring(0, 6)
+      UUID.randomUUID().toString().replace("-", "").substring(0, 6)
     );
     submission.setQuizId(quizId);
     submission.setStudentId(studentId);


### PR DESCRIPTION
#5   What changed
Replaced usages of String.replaceAll(...) with String.replace(...) where the first argument is a plain string and not a regular expression.
In these classes:
QuizSubmissionServiceImpl
QuizServiceImpl
QuestionFactory

- Why this change was made
The underlying implementation of String.replaceAll internally compiles the first argument as a regular expression using java.util.regex.Pattern.compile(). This introduces unnecessary performance overhead when the argument is not actually a regex.

In cases where the first argument is a simple string (i.e., no regex syntax), String.replace provides the same functional behavior but with better performance since it avoids regex compilation.

- Risk
Low — the change only affects cases where the input is clearly not a regex (i.e., no special regex characters like ., *, [], etc.).

- Rule enforcement
This change follows a common best practice and aligns with static analysis rules (e.g., SonarJava's S5361) which flag non-regex uses of String.replaceAll. 