### PR TITLE
Replace all the system.out with logger

### DIFF
--- a/src/main/java/com/lms/listeners/NotificationEventListener.java
+++ b/src/main/java/com/lms/listeners/NotificationEventListener.java
@@ -11,7 +11,8 @@ import com.lms.service.impl.ServiceFacade;
 import lombok.AllArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
-import com.lms.service.NotificationServiceImpl;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.Optional;
 
@@ -19,6 +20,7 @@ import java.util.Optional;
 @Component
 @AllArgsConstructor
 public class NotificationEventListener {
+    private static final Logger logger = LoggerFactory.getLogger(NotificationEventListener.class);
 
     private final EmailService emailService;
     private final SmsService smsService;
@@ -33,10 +35,10 @@ public class NotificationEventListener {
         notification.setMessage(event.getMessage());
         notificationManager.addNotification(notification);
 
-        System.out.println("Notification Event Received:");
-        System.out.println("Student ID: " + event.getUserId());
-        System.out.println("Message: " + event.getMessage());
-        System.out.println("Notification Type: " + event.getNotificationType());
+        logger.info("Notification Event Received:");
+        logger.info("Student ID: {}", event.getUserId());
+        logger.info("Message: {}", event.getMessage());
+        logger.info("Notification Type: {}", event.getNotificationType());
 
         // Simulate notification sending
         switch (event.getNotificationType()) {
@@ -61,7 +63,7 @@ public class NotificationEventListener {
                 emailService.sendEmail(user.getEmail(), subject, event.getMessage());
             }
             catch (Exception e) {
-                System.err.println("Couldn't send the email: " + e);
+                logger.error("Couldn't send the email to {}: {}", user.getEmail(), e.getMessage(), e);
             }
         }).start();
     }
@@ -77,10 +79,10 @@ public class NotificationEventListener {
         new Thread(() -> {
             smsService.sendSMS(otpRequest, Optional.of(user));
         }).start();
-        System.out.println("Sending SMS to student " + event.getUserId() + " for attendance otp of lesson : " + event.getMessage());
+        logger.info("Sending SMS to student {} for attendance OTP of lesson: {}", event.getUserId(), lessonName);
     }
 
     private void sendInAppNotification(NotificationEvent event) {
-        System.out.println("Sending IN-APP notification to student " + event.getUserId() + ": " + event.getMessage());
+        logger.info("Sending IN-APP notification to student {}: {}", event.getUserId(), event.getMessage());
     }
 }

--- a/src/main/java/com/lms/service/impl/EmailService.java
+++ b/src/main/java/com/lms/service/impl/EmailService.java
@@ -1,17 +1,17 @@
 package com.lms.service.impl;
 
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.mail.SimpleMailMessage;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.mail.javamail.MimeMessagePreparator;
 import org.springframework.stereotype.Service;
-
-import static java.awt.SystemColor.text;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Service
 public class EmailService {
 
+    private static final Logger logger = LoggerFactory.getLogger(EmailService.class);
     private final JavaMailSender mailSender;
 
     @Autowired
@@ -28,12 +28,12 @@ public class EmailService {
             messageHelper.setText(body);
         };
 
-        System.out.println("Sending email to " + to);
+        logger.info("Sending email to {}", to);
         try {
             mailSender.send(preparator);
-            System.out.println("Email sent successfully to " + to);
+            logger.info("Email sent successfully to {}", to);
         } catch (Exception e) {
-            System.out.println("Email could not be sent to " + to);
+            logger.error("Email could not be sent to {}", to, e);
         }
     }
 }


### PR DESCRIPTION
#4 - What changed
Removed direct usage of System.out.println and System.err.println in the NotificationEventListener class.

Introduced SLF4J logging using LoggerFactory.

Replaced all logging statements with appropriate logger levels (info, warn, error).

- Why this change was made
Using System.out or System.err is not suitable for production applications because:

Logs are not formatted or centralized.

They can’t be easily filtered or analyzed.

Sensitive data might be printed insecurely.

Violates logging best practices flagged by SonarQube and static analysis tools.

Spring and enterprise applications should rely on a proper logging framework like SLF4J, which supports:

Configurable outputs (file, console, remote).

Structured logging.

Different log levels for different environments.

- Quality rule enforced
This change addresses the SonarQube rule:

"Replace usage of standard output/error streams with a logger"

- Risk
Low — no functional code was changed, only output mechanisms for logging.